### PR TITLE
Adds payable rarity and discount challenges mechanisms for minting

### DIFF
--- a/contracts/Ethernauts.sol
+++ b/contracts/Ethernauts.sol
@@ -21,10 +21,11 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     bytes32 public immutable provenance;
 
     // Can be changed by owner
+    // TODO: add setters
     IChallenge public activeChallenge;
     string public baseTokenURI;
-    uint minPrice;
-    uint maxPrice;
+    uint public minPrice;
+    uint public maxPrice;
 
     // Internal
     uint private _tokensGifted;

--- a/contracts/Ethernauts.sol
+++ b/contracts/Ethernauts.sol
@@ -21,7 +21,6 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     bytes32 public immutable provenance;
 
     // Can be changed by owner
-    // TODO: add setters
     IChallenge public activeChallenge;
     string public baseTokenURI;
     uint public minPrice;
@@ -44,7 +43,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         require(maxTokens_ <= 10000, "Max token supply too large");
         require(daoPercent_ + artistPercent_ == _PERCENT, "Invalid percentages");
         require(provenance_ != bytes32(0), "Invalid provenance hash");
-        require(minPrice_ < maxPrice_, "Invalid price range");
+        require(minPrice_ <= maxPrice_, "Invalid price range");
 
         maxGiftable = maxGiftable_;
         maxTokens = maxTokens_;
@@ -102,6 +101,18 @@ contract Ethernauts is ERC721Enumerable, Ownable {
 
     function setChallenge(IChallenge newChallenge) external onlyOwner {
         activeChallenge = newChallenge;
+    }
+
+    function setMinPrice(uint newMinPrice) external onlyOwner {
+        require(newMinPrice <= maxPrice, "Invalid price range");
+
+        minPrice = newMinPrice;
+    }
+
+    function setMaxPrice(uint newMaxPrice) external onlyOwner {
+        require(minPrice <= newMaxPrice, "Invalid price range");
+
+        maxPrice = newMaxPrice;
     }
 
     function setBaseURI(string memory baseTokenURI_) public onlyOwner {

--- a/contracts/Ethernauts.sol
+++ b/contracts/Ethernauts.sol
@@ -45,7 +45,8 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     // --------------------
 
     function mint() external payable {
-        require(msg.value >= 0.2 ether, "Insufficient payment");
+        require(msg.value >= 0.2 ether, "msg.value too low");
+        require(msg.value <= 14 ether, "msg.value too high");
 
         _mintNext(msg.sender);
     }

--- a/contracts/challenges/BasicChallenge.sol
+++ b/contracts/challenges/BasicChallenge.sol
@@ -1,0 +1,35 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "../interfaces/IChallenge.sol";
+
+contract BasicChallenge is IChallenge {
+    uint public maxDiscounts;
+    uint public givenDiscounts;
+
+    mapping(address => uint) _discountForAddress;
+
+    constructor(uint maxDiscounts_) {
+        maxDiscounts = maxDiscounts_;
+    }
+
+    function register() external {
+        require(givenDiscounts <= maxDiscounts, "Capacity exceeded");
+
+        _discountForAddress[msg.sender] = 0.15 ether;
+
+        givenDiscounts += 1;
+    }
+
+    function discountFor(address who) external view override returns (uint) {
+        return _discountForAddress[who];
+    }
+
+    function discountsGiven() public view override returns (uint) {
+        return givenDiscounts;
+    }
+
+    function discountsAvailable() public view override returns (uint) {
+        return maxDiscounts - givenDiscounts;
+    }
+}

--- a/contracts/challenges/BasicChallenge.sol
+++ b/contracts/challenges/BasicChallenge.sol
@@ -7,7 +7,7 @@ contract BasicChallenge is IChallenge {
     uint public maxDiscounts;
     uint public givenDiscounts;
 
-    mapping(address => uint) _discountForAddress;
+    mapping(address => uint) private _discountForAddress;
 
     constructor(uint maxDiscounts_) {
         maxDiscounts = maxDiscounts_;

--- a/contracts/interfaces/IChallenge.sol
+++ b/contracts/interfaces/IChallenge.sol
@@ -1,0 +1,8 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+interface IChallenge {
+    function discountsAvailable() external view returns (uint);
+    function discountsGiven() external view returns (uint);
+    function discountFor(address who) external view returns (uint);
+}

--- a/contracts/interfaces/IChallenge.sol
+++ b/contracts/interfaces/IChallenge.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 interface IChallenge {
     function discountsAvailable() external view returns (uint);
+
     function discountsGiven() external view returns (uint);
+
     function discountFor(address who) external view returns (uint);
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,3 +1,4 @@
+const ethers = require('ethers');
 require('@nomiclabs/hardhat-ethers');
 
 module.exports = {
@@ -9,4 +10,13 @@ module.exports = {
       url: 'http://localhost:8545',
     },
   },
+  defaults: {
+    maxGiftable: 100,
+    maxTokens: 10000,
+    daoPercent: 950000, // 95%
+    artistPercent: 50000, // 5%
+    minPrice: ethers.utils.parseEther('0.2'),
+    maxPrice: ethers.utils.parseEther('14'),
+    provenance: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  }
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,7 +6,7 @@ module.exports = {
   networks: {
     hardhat: {},
     local: {
-      url: 'http://localhost:8545'
-    }
+      url: 'http://localhost:8545',
+    },
   },
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -18,5 +18,9 @@ module.exports = {
     minPrice: ethers.utils.parseEther('0.2'),
     maxPrice: ethers.utils.parseEther('14'),
     provenance: '0x0000000000000000000000000000000000000000000000000000000000000001',
-  }
+  },
+  overrides: {
+    gasPrice: ethers.utils.parseUnits('100', 'gwei'),
+    gasLimit: 8000000,
+  },
 };

--- a/scripts/bot.js
+++ b/scripts/bot.js
@@ -28,21 +28,21 @@ async function main() {
   await new Promise(() => {});
 }
 
-function _checkIfTokenIdAssetExists(tokenId) {
-  // TODO
-}
+// function _checkIfTokenIdAssetExists(tokenId) {
+//   // TODO
+// }
 
-function _updateLocalAssetIdWithTokenId() {
-  // TODO
-}
+// function _updateLocalAssetIdWithTokenId() {
+//   // TODO
+// }
 
-function _randomlySelectAssetId() {
-  // TODO
-}
+// function _randomlySelectAssetId() {
+//   // TODO
+// }
 
-async function _uploadToIPFS({ tokenId, assetId }) {
-  // TODO
-}
+// async function _uploadToIPFS({ tokenId, assetId }) {
+//   // TODO
+// }
 
 function _loadDeploymentFile(filepath) {
   if (fs.existsSync(filepath)) {
@@ -57,4 +57,4 @@ main()
   .catch((error) => {
     console.error(error);
     process.exit(1);
-  })
+  });

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -3,16 +3,16 @@ const hre = require('hardhat');
 const { ethers } = hre;
 
 const DEPLOYMENT_SCHEMA = {
-  token: ''
+  token: '',
 };
 
 const PARAMETERS = {
   maxGiftable: 100,
   maxTokens: 10000,
-  daoPercent: 950000,   // 95%
+  daoPercent: 950000, // 95%
   artistPercent: 50000, // 5%
-  provenanceHash: ethers.utils.id('beef') // TODO?
-}
+  provenanceHash: ethers.utils.id('beef'), // TODO?
+};
 
 // TODO: Specify gas limit and price to use
 // TODO: Specify owner/deployer EOA
@@ -56,4 +56,4 @@ main()
   .catch((error) => {
     console.error(error);
     process.exit(1);
-  })
+  });

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,17 +1,10 @@
 const fs = require('fs');
 const hre = require('hardhat');
+const Confirm = require('prompt-confirm');
 const { ethers } = hre;
 
 const DEPLOYMENT_SCHEMA = {
   token: '',
-};
-
-const PARAMETERS = {
-  maxGiftable: 100,
-  maxTokens: 10000,
-  daoPercent: 950000, // 95%
-  artistPercent: 50000, // 5%
-  provenanceHash: ethers.utils.id('beef'), // TODO?
 };
 
 // TODO: Specify gas limit and price to use
@@ -25,6 +18,8 @@ async function main() {
     throw new Error(`Token already exists at ${data.token}`);
   }
 
+  await _confirmParameters();
+
   const Ethernauts = await _deployContract();
   console.log(`Ethernauts token deployed at ${Ethernauts.address}`);
 
@@ -32,15 +27,43 @@ async function main() {
   fs.writeFileSync(deploymentPath, JSON.stringify(data, null, 2));
 }
 
+async function _confirmParameters() {
+  console.log('Constructor parameters:');
+  _logObject(hre.config.defaults);
+  console.log('');
+
+  console.log('Overrides:');
+  _logObject(hre.config.overrides);
+  console.log('');
+
+  const confirm = new Confirm('Do you want to depoy with these parameters?');
+  const answer = await confirm.run();
+
+  if (!answer) process.exit(0);
+}
+
 async function _deployContract() {
   const factory = await ethers.getContractFactory('Ethernauts');
-  const Ethernauts = await factory.deploy(...Object.values(PARAMETERS));
+  const Ethernauts = await factory.deploy(
+    ...Object.values(hre.config.defaults),
+    hre.config.overrides
+  );
   console.log('Submitted transaction:', Ethernauts.deployTransaction);
 
   const receipt = await Ethernauts.deployTransaction.wait();
   console.log('Deployment receipt:', receipt);
 
   return Ethernauts;
+}
+
+function _logObject(obj) {
+  const newObj = {};
+
+  Object.keys(obj).map((key) => {
+    newObj[key] = obj[key].toString();
+  });
+
+  console.log(newObj);
 }
 
 function _loadOrCreateDeploymentFile(filepath) {

--- a/scripts/simulate-mints.js
+++ b/scripts/simulate-mints.js
@@ -18,7 +18,6 @@ async function main() {
 
   Ethernauts.on('Transfer', async (from, to, amount, event) => {
     if (from === '0x0000000000000000000000000000000000000000') {
-
       const tokenId = event.args.tokenId.toString();
 
       const tx = await ethers.provider.getTransaction(event.transactionHash);
@@ -36,7 +35,7 @@ async function main() {
     const tx = await Ethernauts.mint({ value: ethers.utils.parseEther(`${value}`) });
     await tx.wait();
 
-    console.log(`Token minted!`);
+    console.log('Token minted!');
   });
 }
 
@@ -73,4 +72,4 @@ main()
   .catch((error) => {
     console.error(error);
     process.exit(1);
-  })
+  });

--- a/scripts/simulate-mints.js
+++ b/scripts/simulate-mints.js
@@ -16,21 +16,27 @@ async function main() {
   console.log(`Interacting with Ethernauts token at ${Ethernauts.address}`);
   console.log(`Tokens minted so far: ${(await Ethernauts.totalSupply()).toString()}`);
 
-  Ethernauts.on('Transfer', (from, to, amount, event) => {
+  Ethernauts.on('Transfer', async (from, to, amount, event) => {
     if (from === '0x0000000000000000000000000000000000000000') {
+
       const tokenId = event.args.tokenId.toString();
 
-      console.log(`Mint detected, tokenId: ${tokenId}`);
+      const tx = await ethers.provider.getTransaction(event.transactionHash);
+      const value = ethers.utils.formatEther(tx.value);
+
+      console.log(`Mint of token #${tokenId} detected. User paid ${value} ETH`);
     }
   });
 
   await _onAnyKeyPress(async () => {
     console.log('Minting a token...');
 
-    const tx = await Ethernauts.mint({ value: ethers.utils.parseEther('0.2') });
-    const receipt = await tx.wait();
+    const value = Math.random() * 13.4 + 0.2;
 
-    console.log(`Token minted! (Gas spent: ${receipt.gasUsed})`);
+    const tx = await Ethernauts.mint({ value: ethers.utils.parseEther(`${value}`) });
+    await tx.wait();
+
+    console.log(`Token minted!`);
   });
 }
 

--- a/test/Challenge.test.js
+++ b/test/Challenge.test.js
@@ -1,0 +1,119 @@
+const { ethers } = require('hardhat');
+const assert = require('assert');
+const assertRevert = require('./utils/assertRevert');
+
+describe('Challenge', () => {
+  let Ethernauts, Challenge;
+
+  let users;
+  let owner, user;
+
+  before('identify signers', async () => {
+    users = await ethers.getSigners();
+    ([owner, user] = users);
+  });
+
+  before('deploy contract', async () => {
+    const factory = await ethers.getContractFactory('Ethernauts');
+    Ethernauts = await factory.deploy(100, 10000, 500000, 500000, ethers.utils.id('beef'));
+  });
+
+  describe('when a challenge is set', () => {
+    before('deploy and set challenge', async () => {
+      const factory = await ethers.getContractFactory('BasicChallenge');
+      Challenge = await factory.deploy(10);
+
+      const tx = await Ethernauts.connect(owner).setChallenge(Challenge.address);
+      await tx.wait();
+    });
+
+    it('shows that the challenge is set', async () => {
+      assert.equal(await Ethernauts.activeChallenge(), Challenge.address);
+    });
+
+    describe('when a user doesnt complete the challenge', () => {
+      it('shows that the user should not get the discount', async () => {
+        assert.deepEqual(await Challenge.discountFor(user.address), ethers.utils.parseEther('0'));
+      });
+
+      describe('when the user tries to buy at a discount', () => {
+        it('reverts', async () => {
+          await assertRevert(
+            Ethernauts.connect(user).mint({ value: ethers.utils.parseEther('0.05') }),
+            'msg.value too low'
+          );
+        });
+      });
+    });
+
+    describe('when a user completes the challenge', () => {
+      before('complete challenge', async () => {
+        const tx = await Challenge.connect(user).register();
+        await tx.wait();
+      });
+
+      it('shows that the user should get the discount', async () => {
+        assert.deepEqual(await Challenge.discountFor(user.address), ethers.utils.parseEther('0.15'));
+      });
+
+      describe('when the user tries to buy at a discount', () => {
+        let receipt;
+        let recordedTotalSupply;
+
+        before('record values', async () => {
+          recordedTotalSupply = await Ethernauts.totalSupply();
+        });
+
+        before('purchase', async () => {
+          const tx = await Ethernauts.connect(user).mint({ value: ethers.utils.parseEther('0.05') });
+          receipt = await tx.wait();
+        });
+
+        it('shows that the total supply increased', async () => {
+          assert.deepEqual(await Ethernauts.totalSupply(), recordedTotalSupply.add(ethers.BigNumber.from('1')));
+        });
+
+        it('shows that the user got the token', async () => {
+          const event = receipt.events.find(e => e.event === 'Transfer');
+
+          assert.equal(await Ethernauts.ownerOf(event.args.tokenId), user.address);
+        });
+
+        describe('when the user tries to buy at a discount again', () => {
+          it('reverts', async () => {
+            await assertRevert(
+              Ethernauts.connect(user).mint({ value: ethers.utils.parseEther('0.05') }),
+              'msg.value too low'
+            );
+          });
+        });
+      });
+    });
+
+    describe('when too many users complete the challenge', () => {
+      let availableDiscounts;
+
+      before('record available discounts', async () => {
+        availableDiscounts = (await Challenge.discountsAvailable()).toNumber();
+      });
+
+      before('fill capacity', async () => {
+        for (let i = 0; i <= availableDiscounts; i++) {
+          const user = users[i + 2];
+
+          const tx = await Challenge.connect(user).register();
+          await tx.wait();
+        }
+      });
+
+      describe('when another user tries to buy at a discount', () => {
+        it('reverts', async () => {
+          await assertRevert(
+            Challenge.connect(owner).register(),
+            'Capacity exceeded'
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/Challenge.test.js
+++ b/test/Challenge.test.js
@@ -15,7 +15,7 @@ describe('Challenge', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-    Ethernauts = await factory.deploy(100, 10000, 500000, 500000, ethers.utils.id('beef'));
+    Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
   });
 
   describe('when a challenge is set', () => {

--- a/test/Challenge.test.js
+++ b/test/Challenge.test.js
@@ -10,7 +10,7 @@ describe('Challenge', () => {
 
   before('identify signers', async () => {
     users = await ethers.getSigners();
-    ([owner, user] = users);
+    [owner, user] = users;
   });
 
   before('deploy contract', async () => {
@@ -53,7 +53,10 @@ describe('Challenge', () => {
       });
 
       it('shows that the user should get the discount', async () => {
-        assert.deepEqual(await Challenge.discountFor(user.address), ethers.utils.parseEther('0.15'));
+        assert.deepEqual(
+          await Challenge.discountFor(user.address),
+          ethers.utils.parseEther('0.15')
+        );
       });
 
       describe('when the user tries to buy at a discount', () => {
@@ -65,16 +68,21 @@ describe('Challenge', () => {
         });
 
         before('purchase', async () => {
-          const tx = await Ethernauts.connect(user).mint({ value: ethers.utils.parseEther('0.05') });
+          const tx = await Ethernauts.connect(user).mint({
+            value: ethers.utils.parseEther('0.05'),
+          });
           receipt = await tx.wait();
         });
 
         it('shows that the total supply increased', async () => {
-          assert.deepEqual(await Ethernauts.totalSupply(), recordedTotalSupply.add(ethers.BigNumber.from('1')));
+          assert.deepEqual(
+            await Ethernauts.totalSupply(),
+            recordedTotalSupply.add(ethers.BigNumber.from('1'))
+          );
         });
 
         it('shows that the user got the token', async () => {
-          const event = receipt.events.find(e => e.event === 'Transfer');
+          const event = receipt.events.find((e) => e.event === 'Transfer');
 
           assert.equal(await Ethernauts.ownerOf(event.args.tokenId), user.address);
         });
@@ -83,7 +91,7 @@ describe('Challenge', () => {
           it('reverts', async () => {
             await assertRevert(
               Ethernauts.connect(user).mint({ value: ethers.utils.parseEther('0.05') }),
-              'msg.value too low'
+              'Cannot receive another discount'
             );
           });
         });
@@ -108,10 +116,7 @@ describe('Challenge', () => {
 
       describe('when another user tries to buy at a discount', () => {
         it('reverts', async () => {
-          await assertRevert(
-            Challenge.connect(owner).register(),
-            'Capacity exceeded'
-          );
+          await assertRevert(Challenge.connect(owner).register(), 'Capacity exceeded');
         });
       });
     });

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const assertRevert = require('./utils/assertRevert');
 const { ethers } = require('hardhat');
 
-describe('Ethernauts', () => {
+describe('General', () => {
   let factory, Ethernauts;
 
   let owner, user;
@@ -16,10 +16,26 @@ describe('Ethernauts', () => {
   });
 
   describe('when deploying the contract with invalid parameters', () => {
+    describe('when deploying with invalid price ranges', () => {
+      it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.minPrice = 200;
+        params.maxPrice = 100;
+
+        await assertRevert(
+          factory.deploy(...Object.values(params)),
+          'Invalid price range'
+        );
+      });
+    });
+
     describe('when deploying with too many giftable tokens', () => {
       it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.maxGiftable = 200;
+
         await assertRevert(
-          factory.deploy(200, 10000, 500000, 500000, ethers.utils.id('beef')),
+          factory.deploy(...Object.values(params)),
           'Max giftable supply too large'
         );
       });
@@ -27,23 +43,23 @@ describe('Ethernauts', () => {
 
     describe('when deploying with an invalid provenance hash', () => {
       it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.provenance = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
         await assertRevert(
-          factory.deploy(
-            200,
-            10000,
-            500000,
-            500000,
-            '0x0000000000000000000000000000000000000000000000000000000000000000'
-          ),
-          'Max giftable supply too large'
+          factory.deploy(...Object.values(params)),
+          'Invalid provenance hash'
         );
       });
     });
 
     describe('when deploying with too many tokens', () => {
       it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.maxTokens = 12000;
+
         await assertRevert(
-          factory.deploy(100, 20000, 500000, 500000, ethers.utils.id('beef')),
+          factory.deploy(...Object.values(params)),
           'Max token supply too large'
         );
       });
@@ -51,15 +67,23 @@ describe('Ethernauts', () => {
 
     describe('when deploying with invalid distribution percentages', () => {
       it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.daoPercent = 500000;
+        params.artistPercent = 600000;
+
         await assertRevert(
-          factory.deploy(100, 10000, 700000, 500000, ethers.utils.id('beef')),
+          factory.deploy(...Object.values(params)),
           'Invalid percentages'
         );
       });
 
       it('reverts', async () => {
+        const params = Object.assign({}, hre.config.defaults);
+        params.daoPercent = 50000;
+        params.artistPercent = 600000;
+
         await assertRevert(
-          factory.deploy(100, 10000, 1000, 50000, ethers.utils.id('beef')),
+          factory.deploy(...Object.values(params)),
           'Invalid percentages'
         );
       });
@@ -67,19 +91,8 @@ describe('Ethernauts', () => {
   });
 
   describe('when deploying the contract with valid paratemeters', () => {
-    const maxGiftable = 100;
-    const maxTokens = 10000;
-    const daoPercent = 950000;
-    const artistPercent = 50000;
-
     before('deploy contract', async () => {
-      Ethernauts = await factory.deploy(
-        maxGiftable,
-        maxTokens,
-        daoPercent,
-        artistPercent,
-        ethers.utils.id('beef')
-      );
+      Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
     });
 
     it('should have set the owner correctly', async () => {
@@ -99,13 +112,13 @@ describe('Ethernauts', () => {
     });
 
     it('shows the correct max supplies', async () => {
-      assert.equal((await Ethernauts.maxGiftable()).toNumber(), maxGiftable);
-      assert.equal((await Ethernauts.maxTokens()).toNumber(), maxTokens);
+      assert.equal((await Ethernauts.maxGiftable()).toNumber(), hre.config.defaults.maxGiftable);
+      assert.equal((await Ethernauts.maxTokens()).toNumber(), hre.config.defaults.maxTokens);
     });
 
     it('shows the correct percentages', async () => {
-      assert.equal((await Ethernauts.daoPercent()).toNumber(), daoPercent);
-      assert.equal((await Ethernauts.artistPercent()).toNumber(), artistPercent);
+      assert.equal((await Ethernauts.daoPercent()).toNumber(), hre.config.defaults.daoPercent);
+      assert.equal((await Ethernauts.artistPercent()).toNumber(), hre.config.defaults.artistPercent);
     });
 
     it('shows that the expexted interfaces are supported', async () => {

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -86,6 +86,10 @@ describe('Ethernauts', () => {
       assert.equal(await Ethernauts.owner(), owner.address);
     });
 
+    it('shows that no challenge is set', async () => {
+      assert.equal(await Ethernauts.activeChallenge(), '0x0000000000000000000000000000000000000000');
+    });
+
     it('should have set the name and symbol correctly', async () => {
       assert.equal(await Ethernauts.name(), 'Ethernauts');
       assert.equal(await Ethernauts.symbol(), 'ETHNTS');

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 describe('Ethernauts', () => {
   let factory, Ethernauts;
 
-  let owner;
+  let owner, user;
 
   before('identify signers', async () => {
     [owner, user] = await ethers.getSigners();
@@ -87,7 +87,10 @@ describe('Ethernauts', () => {
     });
 
     it('shows that no challenge is set', async () => {
-      assert.equal(await Ethernauts.activeChallenge(), '0x0000000000000000000000000000000000000000');
+      assert.equal(
+        await Ethernauts.activeChallenge(),
+        '0x0000000000000000000000000000000000000000'
+      );
     });
 
     it('should have set the name and symbol correctly', async () => {
@@ -122,10 +125,7 @@ describe('Ethernauts', () => {
           Ethernauts.connect(user).setBaseURI('someURI'),
           'caller is not the owner'
         );
-        await assertRevert(
-          Ethernauts.connect(user).gift(user.address),
-          'caller is not the owner'
-        );
+        await assertRevert(Ethernauts.connect(user).gift(user.address), 'caller is not the owner');
       });
     });
   });

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -116,6 +116,21 @@ describe('General', () => {
       assert.ok(await Ethernauts.supportsInterface('0x780e9d63')); // ERC721Enumarable
     });
 
+    describe('when the owner calls protected functions', () => {
+      it('allows the owner to change min and max price', async () => {
+        let tx;
+
+        tx = await Ethernauts.connect(owner).setMinPrice(0);
+        await tx.wait();
+
+        tx = await Ethernauts.connect(owner).setMaxPrice(0);
+        await tx.wait();
+
+        assert.equal(await Ethernauts.minPrice(), '0');
+        assert.equal(await Ethernauts.maxPrice(), '0');
+      });
+    });
+
     describe('when a regular user tries to call protected functions', () => {
       it('reverts', async () => {
         await assertRevert(

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -127,6 +127,7 @@ describe('General', () => {
           'caller is not the owner'
         );
         await assertRevert(Ethernauts.connect(user).gift(user.address), 'caller is not the owner');
+        await assertRevert(Ethernauts.connect(user).setChallenge(user.address), 'caller is not the owner');
       });
     });
   });

--- a/test/General.test.js
+++ b/test/General.test.js
@@ -22,10 +22,7 @@ describe('General', () => {
         params.minPrice = 200;
         params.maxPrice = 100;
 
-        await assertRevert(
-          factory.deploy(...Object.values(params)),
-          'Invalid price range'
-        );
+        await assertRevert(factory.deploy(...Object.values(params)), 'Invalid price range');
       });
     });
 
@@ -46,10 +43,7 @@ describe('General', () => {
         const params = Object.assign({}, hre.config.defaults);
         params.provenance = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
-        await assertRevert(
-          factory.deploy(...Object.values(params)),
-          'Invalid provenance hash'
-        );
+        await assertRevert(factory.deploy(...Object.values(params)), 'Invalid provenance hash');
       });
     });
 
@@ -58,10 +52,7 @@ describe('General', () => {
         const params = Object.assign({}, hre.config.defaults);
         params.maxTokens = 12000;
 
-        await assertRevert(
-          factory.deploy(...Object.values(params)),
-          'Max token supply too large'
-        );
+        await assertRevert(factory.deploy(...Object.values(params)), 'Max token supply too large');
       });
     });
 
@@ -71,10 +62,7 @@ describe('General', () => {
         params.daoPercent = 500000;
         params.artistPercent = 600000;
 
-        await assertRevert(
-          factory.deploy(...Object.values(params)),
-          'Invalid percentages'
-        );
+        await assertRevert(factory.deploy(...Object.values(params)), 'Invalid percentages');
       });
 
       it('reverts', async () => {
@@ -82,10 +70,7 @@ describe('General', () => {
         params.daoPercent = 50000;
         params.artistPercent = 600000;
 
-        await assertRevert(
-          factory.deploy(...Object.values(params)),
-          'Invalid percentages'
-        );
+        await assertRevert(factory.deploy(...Object.values(params)), 'Invalid percentages');
       });
     });
   });
@@ -118,7 +103,10 @@ describe('General', () => {
 
     it('shows the correct percentages', async () => {
       assert.equal((await Ethernauts.daoPercent()).toNumber(), hre.config.defaults.daoPercent);
-      assert.equal((await Ethernauts.artistPercent()).toNumber(), hre.config.defaults.artistPercent);
+      assert.equal(
+        (await Ethernauts.artistPercent()).toNumber(),
+        hre.config.defaults.artistPercent
+      );
     });
 
     it('shows that the expexted interfaces are supported', async () => {

--- a/test/Gift.test.js
+++ b/test/Gift.test.js
@@ -21,7 +21,7 @@ describe('Gift', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-    Ethernauts = await factory.deploy(100, 10000, 500000, 500000, ethers.utils.id('beef'));
+    Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
   });
 
   describe('when a regular user tries to gift an NFT', () => {

--- a/test/Mint.test.js
+++ b/test/Mint.test.js
@@ -78,8 +78,10 @@ describe('Mint', () => {
         });
 
         before('mint', async () => {
+          const value = Math.random() * 13.4 + 0.2;
+
           tx = await Ethernauts.connect(user).mint({
-            value: ethers.utils.parseEther('0.2'),
+            value: ethers.utils.parseEther(`${value}`),
           });
 
           receipt = await tx.wait();

--- a/test/Mint.test.js
+++ b/test/Mint.test.js
@@ -37,7 +37,18 @@ describe('Mint', () => {
         Ethernauts.connect(user).mint({
           value: ethers.utils.parseEther('0.01'),
         }),
-        'Insufficient payment'
+        'msg.value too low'
+      );
+    });
+  });
+
+  describe('when attempting to mint with too much ETH', () => {
+    it('reverts', async () => {
+      await assertRevert(
+        Ethernauts.connect(user).mint({
+          value: ethers.utils.parseEther('15'),
+        }),
+        'msg.value too high'
       );
     });
   });

--- a/test/Mint.test.js
+++ b/test/Mint.test.js
@@ -23,7 +23,10 @@ describe('Mint', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-    Ethernauts = await factory.deploy(100, 100, 500000, 500000, ethers.utils.id('beef'));
+
+    const params = Object.assign({}, hre.config.defaults);
+    params.maxTokens = 100;
+    Ethernauts = await factory.deploy(...Object.values(params));
   });
 
   before('set base URI', async () => {

--- a/test/Transfer.test.js
+++ b/test/Transfer.test.js
@@ -12,7 +12,7 @@ describe('Transfer', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-    Ethernauts = await factory.deploy(100, 10000, 500000, 500000, ethers.utils.id('beef'));
+    Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
   });
 
   describe('when a user mints a token', () => {

--- a/test/Withdraw.test.js
+++ b/test/Withdraw.test.js
@@ -17,13 +17,7 @@ describe('Withdraw', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-    Ethernauts = await factory.deploy(
-      100,
-      10000,
-      DAO_PERCENT * PERCENT_SCALAR,
-      ARTIST_PERCENT * PERCENT_SCALAR,
-      ethers.utils.id('beef')
-    );
+    Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
   });
 
   describe('when some tokens have been minted', () => {


### PR DESCRIPTION
Introduces two new mechanisms that apply when minting:

### Payable rarity:
Basically, the min price to mint an NFT is 0.2 ETH, but the user can pay more, up to 14 ETH in total. All that the contract does is ensure that `msg.value` is within this range. It will be up to the script that uploads assets and metadata to IPFS to boost rarity when picking an assetId for the tokenId minted. This allows users to basically pick their own price. The idea would be to communicate this well, and make it clear that buying an NFT is a donation to the EthernautDAO basically.

### Discounts challenges:
Allows the owner to set and change a "challenge" contract. When minting, the contract will check if such a contract exists, and if the user hasn't previously received a discount. If so, it will give the user a discount given that the user has completed the challenge, which can be literally anything. In the example provided, the user merely needs to register in the challenge contract. More interesting challenges could involve registering to proof of humanity, passing some arbitrary rules via a merkle tree validation (e.g. early community members), or even challenges similar to the original Ethernaut game. Challenges have a limited capacity. Given that the EthernautDAO will be able to set these at will, any game-ability of the challenges shouldn't have too much impact, and should be fun.
Note: Given current gas costs in mainnet, this second mechanism will probably only work on an L2 like Optimism.