### PR TITLE
Add npm workspaces with package-lock files checker

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -1,0 +1,10 @@
+name: "Workspaces package-lock.json files"
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: scripts/check-packages.sh

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+save-prefix=''

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "EthernautDAO's first NFT project",
   "main": "index.js",
   "homepage": "https://github.com/ethernautdao/ethernauts#readme",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ethernautdao/ethernauts.git"

--- a/packages/dapp/.npmrc
+++ b/packages/dapp/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+save-prefix=''

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dapp",
+  "version": "0.0.1",
+  "description": "Ethernauts DAPP",
+  "main": "index.js",
+  "private": true,
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ethernautdao/ethernauts.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ethernautdao/ethernauts/issues"
+  },
+  "homepage": "https://github.com/ethernautdao/ethernauts#readme"
+}

--- a/packages/minter/.npmrc
+++ b/packages/minter/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+save-prefix=''

--- a/packages/minter/package.json
+++ b/packages/minter/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "minter",
+  "version": "0.0.1",
+  "description": "Ethernauts server that reacts to mint events processing and uploading assets",
+  "main": "index.js",
+  "private": true,
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ethernautdao/ethernauts.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ethernautdao/ethernauts/issues"
+  },
+  "homepage": "https://github.com/ethernautdao/ethernauts#readme"
+}

--- a/scripts/check-packages.sh
+++ b/scripts/check-packages.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Check that package-lock.json file does not exist on any package of the workspace
+for workspace in $(find packages/* -type d -maxdepth 0)
+do
+  lockfile="$workspace/package-lock.json"
+  if [ -f "$lockfile" ]; then
+    echo "The file $lockfile was found, please delete it and install dependencies using npm's Workspaces functionality"
+    echo ' - More info 👉 https://docs.npmjs.com/cli/v7/using-npm/workspaces'
+    exit 1
+  fi
+done


### PR DESCRIPTION
Closes #50 

This PR adds [`npm workspaces`](https://docs.npmjs.com/cli/v7/using-npm/workspaces) so we can use monorepo like  workflows. Starting with a package for the DAPP and another for the server/bot which listens for minting events.