### PR TITLE
State change events

### DIFF
--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -19,9 +19,16 @@ contract Ethernauts is ERC721Enumerable, Ownable {
 
     // Can be changed by owner
     string public baseTokenURI;
+    event BaseTokenURIChanged(string baseTokenURI);
+
     uint public mintPrice;
+    event MintPriceChanged(uint mintPrice);
+
     uint public earlyMintPrice;
+    event EarlyMintPriceChanged(uint earlyMintPrice);
+
     address public couponSigner;
+    event CouponSignerChanged(address couponSigner);
 
     // Internal usage
     uint private _tokensGifted;
@@ -35,6 +42,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         Open // Anyone can mint
     }
     SaleState public currentSaleState;
+    event SaleStateChanged(SaleState state);
 
     constructor(
         uint definitiveMaxGiftable,
@@ -176,24 +184,29 @@ contract Ethernauts is ERC721Enumerable, Ownable {
 
     function setMintPrice(uint newMintPrice) external onlyOwner {
         mintPrice = newMintPrice;
+        emit MintPriceChanged(newMintPrice);
     }
 
     function setEarlyMintPrice(uint newEarlyMintPrice) external onlyOwner {
         earlyMintPrice = newEarlyMintPrice;
+        emit EarlyMintPriceChanged(newEarlyMintPrice);
     }
 
     function setBaseURI(string memory newBaseTokenURI) external onlyOwner {
         baseTokenURI = newBaseTokenURI;
+        emit BaseTokenURIChanged(newBaseTokenURI);
     }
 
     function setSaleState(SaleState newSaleState) external onlyOwner {
         require(newSaleState != currentSaleState, "Invalid new state");
 
         currentSaleState = newSaleState;
+        emit SaleStateChanged(newSaleState);
     }
 
     function setCouponSigner(address newCouponSigner) external onlyOwner {
         couponSigner = newCouponSigner;
+        emit CouponSignerChanged(newCouponSigner);
     }
 
     function withdraw(address payable beneficiary) external onlyOwner {

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -7,7 +7,9 @@ module.exports = {
   solidity: '0.8.4',
   defaultNetwork: 'hardhat',
   networks: {
-    hardhat: {},
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
     local: {
       url: 'http://localhost:8545',
     },

--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const { ethers } = require('hardhat');
+
+describe('Test events emitted', () => {
+  let Ethernauts;
+
+  let users;
+  let owner, user;
+
+  let tx, receipt;
+
+  const baseURI = 'http://deadpine.io/';
+
+  before('identify signers', async () => {
+    users = await ethers.getSigners();
+    [owner, user] = users;
+  });
+
+  before('deploy contract', async () => {
+    const factory = await ethers.getContractFactory('Ethernauts');
+
+    const params = Object.assign({}, hre.config.defaults);
+    params.maxTokens = 100;
+    params.maxGiftable = 10;
+
+    Ethernauts = await factory.deploy(...Object.values(params));
+  });
+
+  before('set base URI', async () => {
+    const tx = await Ethernauts.connect(owner).setBaseURI(baseURI);
+    await tx.wait();
+  });
+
+  describe('When sale state changes', () => {
+    it('shows SaleStateChanged event is emitted with state Early', async () => {
+      receipt = await (await Ethernauts.connect(owner).setSaleState(1)).wait();
+      const event = receipt.events.find((e) => e.event === 'SaleStateChanged');
+      assert.equal(event.args.state, 1);
+    });
+
+    it('shows SaleStateChanged event is emitted with state Open', async () => {
+      receipt = await (await Ethernauts.connect(owner).setSaleState(2)).wait();
+      const event = receipt.events.find((e) => e.event === 'SaleStateChanged');
+      assert.equal(event.args.state, 2);
+    });
+  });
+
+  describe('When mint price changes', () => {
+    it('shows MintPriceChanged event is emitted', async () => {
+      const newPrice = ethers.utils.parseEther('0.01');
+      tx = await Ethernauts.connect(owner).setMintPrice(newPrice);
+      receipt = await tx.wait();
+      const event = receipt.events.find((e) => e.event === 'MintPriceChanged');
+      assert.equal(event.args.mintPrice.toString(), newPrice.toString());
+    });
+  });
+
+  describe('When early mint price changes', () => {
+    it('shows EarlyMintPriceChanged event is emitted', async () => {
+      const newPrice = ethers.utils.parseEther('0.01');
+      tx = await Ethernauts.connect(owner).setEarlyMintPrice(newPrice);
+      receipt = await tx.wait();
+      const event = receipt.events.find((e) => e.event === 'EarlyMintPriceChanged');
+      assert.equal(event.args.earlyMintPrice.toString(), newPrice.toString());
+    });
+  });
+
+  describe('When coupon signer changes', () => {
+    it('shows CouponSignerChanged event is emitted', async () => {
+      receipt = await (await Ethernauts.connect(owner).setCouponSigner(user.address)).wait();
+      const event = receipt.events.find((e) => e.event === 'CouponSignerChanged');
+      assert.equal(event.args.couponSigner, user.address);
+    });
+  });
+
+  describe('When base URI changes', () => {
+    it('shows BaseTokenURIChanged event is emitted', async () => {
+      receipt = await (await Ethernauts.connect(owner).setBaseURI('http://pinedead.io/')).wait();
+      const event = receipt.events.find((e) => e.event === 'BaseTokenURIChanged');
+      assert.equal(event.args.baseTokenURI, 'http://pinedead.io/');
+    });
+  });
+});


### PR DESCRIPTION
closes #48 

This PR aims to add events in the Ethernauts contracts. As per the discussions on the original issue, it, at the moment, adds four new events. 

- MintPriceChanged
- EarlyMintPriceChanged
- CouponSignerChanged
- BaseTokenURIChanged

The list is not final yet. This PR is a work in progress. Please feel free to suggest any events that are not included or if you think one of the included events should be excluded. 

Also, please review very critically. It is my first solidity PR 🙂 