### PR TITLE
A test to expect for an error when the owner tries to change the baseURL but the metadata has already frozen

### DIFF
--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -95,5 +95,14 @@ describe('Test events emitted', () => {
       const event = receipt.events.find((e) => e.event === 'PermanentURITriggered');
       assert.equal(event.args.value, true);
     });
+    context('and owner attempts to set baseURI', () => {
+      it('reverts', async () => {
+        await (await Ethernauts.connect(owner).setPermanentURI()).wait();
+        await assertRevert(
+          Ethernauts.connect(owner).setBaseURI('http://pinedead.io/'),
+          'NFTs minting finished'
+        );
+      });
+    });
   });
 });

--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { ethers } = require('hardhat');
+const assertRevert = require('./utils/assertRevert');
 
 describe('Test events emitted', () => {
   let Ethernauts;

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -97,25 +97,25 @@ describe('Random', () => {
 
       it('shows that the random number is set', async () => {
         assert.notEqual(await Ethernauts.getRandomNumberForBatch(0), '0');
-        assert.equal(await Ethernauts.getRandomNumberCount(), 1)
+        assert.equal(await Ethernauts.getRandomNumberCount(), 1);
       });
-      
+
       it('shows the definitive URI for all minted tokens', async () => {
         const randomNumber = await Ethernauts.getRandomNumberForBatch(0);
-        
+
         for (let i = 0; i < batchSize; i++) {
           await validateTokenUri(i, randomNumber);
         }
       });
-      
+
       describe('when the tokens for the next batch are minted', () => {
         before('mint some tokens', async () => {
           await mintTokens(batchSize);
         });
-        
+
         it('shows that the token supply increased accordingly', async () => {
           assert.equal(await Ethernauts.totalSupply(), 2 * batchSize);
-          assert.equal(await Ethernauts.getRandomNumberCount(), '2')
+          assert.equal(await Ethernauts.getRandomNumberCount(), '2');
         });
 
         it('shows that the random number is set', async () => {

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -97,23 +97,25 @@ describe('Random', () => {
 
       it('shows that the random number is set', async () => {
         assert.notEqual(await Ethernauts.getRandomNumberForBatch(0), '0');
+        assert.equal(await Ethernauts.getRandomNumberCount(), 1)
       });
-
+      
       it('shows the definitive URI for all minted tokens', async () => {
         const randomNumber = await Ethernauts.getRandomNumberForBatch(0);
-
+        
         for (let i = 0; i < batchSize; i++) {
           await validateTokenUri(i, randomNumber);
         }
       });
-
+      
       describe('when the tokens for the next batch are minted', () => {
         before('mint some tokens', async () => {
           await mintTokens(batchSize);
         });
-
+        
         it('shows that the token supply increased accordingly', async () => {
           assert.equal(await Ethernauts.totalSupply(), 2 * batchSize);
+          assert.equal(await Ethernauts.getRandomNumberCount(), '2')
         });
 
         it('shows that the random number is set', async () => {

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -6,8 +6,8 @@ describe('Random', () => {
 
   let owner;
 
-  const maxTokens = 1000;
-  const batchSize = 100;
+  const maxTokens = 100;
+  const batchSize = 10;
 
   const baseURI = 'http://deadpine.io/';
 

--- a/packages/hardhat/test/State.test.js
+++ b/packages/hardhat/test/State.test.js
@@ -27,7 +27,7 @@ describe('State Changes', () => {
     assert.equal(await Ethernauts.currentSaleState(), 0);
   });
 
-  it('owner can freele change from one state to another (not complete)', async () => {
+  it('owner can freely change from one state to another (not complete)', async () => {
     await (await Ethernauts.connect(owner).setSaleState(1)).wait();
     assert.equal(await Ethernauts.currentSaleState(), 1);
 


### PR DESCRIPTION
Add reverting test for `setBaseURI` function when `permanentUrl` is set to `true`

Closes #127 