### PR TITLE
Add BatchEnd event when last token on batch is minted

### DIFF
--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -12,7 +12,7 @@ describe('Random', () => {
   const baseURI = 'http://deadpine.io/';
 
   async function mintTokens(num) {
-    let value = ethers.utils.parseEther('0.2');
+    const value = ethers.utils.parseEther('0.2');
 
     for (let i = 0; i < num; i++) {
       await (await Ethernauts.connect(owner).mint({ value })).wait();
@@ -108,6 +108,13 @@ describe('Random', () => {
         }
       });
 
+      it('emitted a BatchEnd event', async () => {
+        const events = await Ethernauts.queryFilter('BatchEnd');
+        assert.equal(events.length, 1);
+        const batchId = events[events.length - 1].args[0];
+        assert.equal(Number(batchId), 0);
+      });
+
       describe('when the tokens for the next batch are minted', () => {
         before('mint some tokens', async () => {
           await mintTokens(batchSize);
@@ -130,6 +137,13 @@ describe('Random', () => {
           }
         });
 
+        it('emitted a BatchEnd event', async () => {
+          const events = await Ethernauts.queryFilter('BatchEnd');
+          assert.equal(events.length, 2);
+          const batchId = events[1].args[0];
+          assert.equal(Number(batchId), 1);
+        });
+
         describe('when the remaining batches are minted', () => {
           before('mint all tokens', async () => {
             await mintTokens(maxTokens - 2 * batchSize);
@@ -146,6 +160,13 @@ describe('Random', () => {
 
             const uriSet = new Set(uris);
             assert.equal(uriSet.size, maxTokens);
+          });
+
+          it('emitted all the BatchEnd events', async () => {
+            const events = await Ethernauts.queryFilter('BatchEnd');
+            assert.equal(events.length, 10);
+            const batchId = events[events.length - 1].args[0];
+            assert.equal(Number(batchId), 9);
           });
         });
       });


### PR DESCRIPTION
This PR adds the emit of the `BatchEnd` event with the last token on a given batch is minted. It is going to be used by the keeper to upload the necessary assets for the finished batches.