### PR TITLE
Fix random number generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,6 @@ services:
       context: .
       dockerfile: docker/hardhat.Dockerfile
     restart: always
-    volumes:
-      - ./packages/hardhat/deployments:/src/packages/hardhat/deployments
-      - ./packages/hardhat/artifacts:/src/packages/hardhat/artifacts
-      - ./packages/hardhat/cache:/src/packages/hardhat/cache
-      - ./packages/hardhat/tasks:/src/packages/hardhat/tasks
     ports:
       - 8545:8545
     command: npm run start:hardhat:node -w @ethernauts/hardhat
@@ -20,6 +15,7 @@ services:
       context: .
       dockerfile: docker/hardhat.Dockerfile
     volumes:
+      - ./packages/hardhat/contracts:/src/packages/hardhat/contracts
       - ./packages/hardhat/deployments:/src/packages/hardhat/deployments
       - ./packages/hardhat/artifacts:/src/packages/hardhat/artifacts
       - ./packages/hardhat/cache:/src/packages/hardhat/cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./packages/hardhat/artifacts:/src/packages/hardhat/artifacts
       - ./packages/hardhat/cache:/src/packages/hardhat/cache
       - ./packages/hardhat/tasks:/src/packages/hardhat/tasks
-    command: sh -c "/wait && rm -f ./packages/hardhat/deployments/docker.json && npm run -w @ethernauts/hardhat start:hardhat:compile && npm run -w @ethernauts/hardhat start:hardhat:deploy -- --network docker"
+    command: sh -c "/wait && rm -f /src/packages/hardhat/deployments/docker.json && npm run -w @ethernauts/hardhat start:hardhat:compile && npm run -w @ethernauts/hardhat start:hardhat:deploy -- --network docker"
     environment:
       WAIT_HOSTS: hardhat-node:8545
     depends_on:
@@ -50,7 +50,7 @@ services:
       context: .
       dockerfile: docker/keeper.Dockerfile
     restart: always
-    command: sh -c "npx --yes just-wait -p ./packages/hardhat/deployments/docker.json --timeout 10 && npm run -w @ethernauts/keeper queue -- --network docker"
+    command: sh -c "npx --yes wait-on -l ./packages/hardhat/deployments/docker.json && npm run -w @ethernauts/keeper queue -- --network docker"
     environment:
       NODE_ENV: development
       REDIS_HOST: redis

--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -312,13 +312,12 @@ contract Ethernauts is ERC721Enumerable, Ownable {
 
         _mint(to, tokenId);
 
-        uint256 currentBatchId = _randomNumbers.length;
-        uint256 maxTokenIdInBatch = batchSize * (currentBatchId + 1) - 2;
+        uint256 currentBatchId = tokenId / batchSize;
+        uint256 maxTokenIdInBatch = batchSize * (currentBatchId + 1) - 1;
 
         if (tokenId == maxTokenIdInBatch) {
-            emit BatchEnd(currentBatchId);
-        } else if (tokenId == maxTokenIdInBatch + 1) {
             _generateRandomNumber();
+            emit BatchEnd(currentBatchId);
         }
     }
 

--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -68,7 +68,6 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     event CouponSignerChanged(address couponSigner);
     event WithdrawTriggered(address beneficiary);
     event PermanentURITriggered(bool value);
-    event BatchEnd(uint256 batchId);
     event UrlChangerChanged(address urlChanger);
 
     constructor(
@@ -317,7 +316,6 @@ contract Ethernauts is ERC721Enumerable, Ownable {
 
         if (tokenId == maxTokenIdInBatch) {
             _generateRandomNumber();
-            emit BatchEnd(currentBatchId);
         }
     }
 

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -108,13 +108,6 @@ describe('Random', () => {
         }
       });
 
-      it('emitted a BatchEnd event', async () => {
-        const events = await Ethernauts.queryFilter('BatchEnd');
-        assert.equal(events.length, 1);
-        const batchId = events[events.length - 1].args[0];
-        assert.equal(Number(batchId), 0);
-      });
-
       describe('when the tokens for the next batch are minted', () => {
         before('mint some tokens', async () => {
           await mintTokens(batchSize);
@@ -137,13 +130,6 @@ describe('Random', () => {
           }
         });
 
-        it('emitted a BatchEnd event', async () => {
-          const events = await Ethernauts.queryFilter('BatchEnd');
-          assert.equal(events.length, 2);
-          const batchId = events[1].args[0];
-          assert.equal(Number(batchId), 1);
-        });
-
         describe('when the remaining batches are minted', () => {
           before('mint all tokens', async () => {
             await mintTokens(maxTokens - 2 * batchSize);
@@ -160,13 +146,6 @@ describe('Random', () => {
 
             const uriSet = new Set(uris);
             assert.equal(uriSet.size, maxTokens);
-          });
-
-          it('emitted all the BatchEnd events', async () => {
-            const events = await Ethernauts.queryFilter('BatchEnd');
-            assert.equal(events.length, 10);
-            const batchId = events[events.length - 1].args[0];
-            assert.equal(Number(batchId), 9);
           });
         });
       });


### PR DESCRIPTION
This fixes a bug were we generated the random number for the current batch at the beginning of it, instead of the end. This would let the users know the random number and have the ability to infer which token they would get.