### PR TITLE
Updates for deployment script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./packages/hardhat:/src/packages/hardhat
       - /src/node_modules
       - /src/packages/hardhat/node_modules
-    command: sh -c "/wait && rm -f /src/packages/hardhat/deployments/docker.json && npm run -w @ethernauts/hardhat start:hardhat:compile && npm run -w @ethernauts/hardhat start:hardhat:deploy -- --network docker"
+    command: sh -c "/wait && rm -f /src/packages/hardhat/deployments/docker.json && npm run -w @ethernauts/hardhat start:hardhat:compile && npm run -w @ethernauts/hardhat start:hardhat:deploy -- --no-confirm --no-verify --clear --network docker"
     environment:
       WAIT_HOSTS: hardhat-node:8545
     depends_on:

--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -76,7 +76,8 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         uint256 definitiveBatchSize,
         uint256 initialMintPrice,
         uint256 initialEarlyMintPrice,
-        address initialCouponSigner
+        address initialCouponSigner,
+        address initialUrlChanger
     ) ERC721("Ethernauts", "NAUTS") {
         if (definitiveMaxGiftable > 100) {
             revert MaxGiftableError({gifted: definitiveMaxGiftable, maxGift: 100});
@@ -93,6 +94,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         mintPrice = initialMintPrice;
         earlyMintPrice = initialEarlyMintPrice;
         couponSigner = initialCouponSigner;
+        urlChanger = initialUrlChanger;
 
         currentSaleState = SaleState.Paused;
     }

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -48,15 +48,16 @@ module.exports = {
     apiKey: `${process.env.ETHERSCAN_API}`,
   },
   defaults: {
-    maxGiftable: 100,
-    maxTokens: 10000,
-    batchSize: 50,
-    mintPrice: ethers.utils.parseEther('0.2'),
-    earlyMintPrice: ethers.utils.parseEther('0.015'),
+    definitiveMaxGiftable: 100,
+    definitiveMaxTokens: 10000,
+    definitiveBatchSize: 50,
+    initialMintPrice: ethers.utils.parseEther('0.2'),
+    initialEarlyMintPrice: ethers.utils.parseEther('0.015'),
 
     // Default hardhat signer[0]
     // Will be changed at runtime if targeting a real network.
     initialCouponSigner: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    initialUrlChanger: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   },
   overrides: {
     gasPrice: ethers.utils.parseUnits('100', 'gwei'),

--- a/packages/hardhat/tasks/deploy.js
+++ b/packages/hardhat/tasks/deploy.js
@@ -63,7 +63,7 @@ async function _parseConstructorArguments(params = {}) {
     .find(({ type }) => type === 'constructor')
     .inputs.map(({ name }) => name);
 
-  // Create an array with the constructor params in correct oreder
+  // Create an array with the constructor params in correct order
   return paramNames.reduce((constructorArgs, paramName) => {
     if (!params[paramName]) {
       throw new Error(`Missing constructor parameter "${paramName}"`);

--- a/packages/hardhat/test/Early.test.js
+++ b/packages/hardhat/test/Early.test.js
@@ -36,9 +36,7 @@ describe('Early mint', () => {
 
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
-
-    const params = Object.assign({}, hre.config.defaults);
-    Ethernauts = await factory.deploy(...Object.values(params));
+    Ethernauts = await factory.deploy(...Object.values(hre.config.defaults));
   });
 
   describe('when attempting to mint when the early sale is not open', () => {
@@ -86,7 +84,7 @@ describe('Early mint', () => {
       it('reverts', async () => {
         await assertRevert(
           Ethernauts.connect(user).mintEarly(coupon, {
-            value: hre.config.defaults.earlyMintPrice,
+            value: hre.config.defaults.initialEarlyMintPrice,
           }),
           'InvalidUserCouponError(false)'
         );
@@ -134,7 +132,7 @@ describe('Early mint', () => {
 
           before('early mint', async () => {
             tx = await Ethernauts.connect(user).mintEarly(coupon, {
-              value: hre.config.defaults.earlyMintPrice,
+              value: hre.config.defaults.initialEarlyMintPrice,
             });
 
             receipt = await tx.wait();
@@ -214,7 +212,7 @@ describe('Early mint', () => {
         it('reverts', async () => {
           await assertRevert(
             Ethernauts.connect(someUser).mintEarly(await signCouponForAddress(someUser.address), {
-              value: hre.config.defaults.earlyMintPrice,
+              value: hre.config.defaults.initialEarlyMintPrice,
             }),
             'RedeemedCouponError(true)'
           );
@@ -227,7 +225,7 @@ describe('Early mint', () => {
 
           await assertRevert(
             Ethernauts.connect(someUser).mintEarly(await signCouponForAddress(user.address), {
-              value: hre.config.defaults.earlyMintPrice,
+              value: hre.config.defaults.initialEarlyMintPrice,
             }),
             'InvalidUserCouponError(false)'
           );

--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -20,9 +20,9 @@ describe('Test events emitted', () => {
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
-    const params = Object.assign({}, hre.config.defaults);
-    params.maxTokens = 100;
-    params.maxGiftable = 10;
+    const params = { ...hre.config.defaults };
+    params.definitiveMaxGiftable = 10;
+    params.definitiveMaxTokens = 100;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/hardhat/test/General.test.js
+++ b/packages/hardhat/test/General.test.js
@@ -18,26 +18,24 @@ describe('General', () => {
   describe('when deploying the contract with invalid parameters', () => {
     describe('when deploying with too many giftable tokens', () => {
       it('reverts', async () => {
-        const params = Object.assign({}, hre.config.defaults);
-        params.maxGiftable = 200;
-        const max = 100;
+        const params = { ...hre.config.defaults };
+        params.definitiveMaxGiftable = 200;
 
         await assertRevert(
           factory.deploy(...Object.values(params)),
-          `MaxGiftableError(${params.maxGiftable}, ${max})`
+          `MaxGiftableError(${params.definitiveMaxGiftable}, 100)`
         );
       });
     });
 
     describe('when deploying with too many tokens', () => {
       it('reverts', async () => {
-        const params = Object.assign({}, hre.config.defaults);
-        params.maxTokens = 12000;
-        const max = 10000;
+        const params = { ...hre.config.defaults };
+        params.definitiveMaxTokens = 12000;
 
         await assertRevert(
           factory.deploy(...Object.values(params)),
-          `MaxTokensError(${params.maxTokens}, ${max})`
+          `MaxTokensError(${params.definitiveMaxTokens}, 10000)`
         );
       });
     });
@@ -66,12 +64,18 @@ describe('General', () => {
     });
 
     it('shows the correct max supplies', async () => {
-      assert.equal((await Ethernauts.maxGiftable()).toNumber(), hre.config.defaults.maxGiftable);
-      assert.equal((await Ethernauts.maxTokens()).toNumber(), hre.config.defaults.maxTokens);
+      assert.equal(
+        (await Ethernauts.maxGiftable()).toNumber(),
+        hre.config.defaults.definitiveMaxGiftable
+      );
+      assert.equal(
+        (await Ethernauts.maxTokens()).toNumber(),
+        hre.config.defaults.definitiveMaxTokens
+      );
     });
 
     it('shows the correct mint price', async () => {
-      assert.equal((await Ethernauts.mintPrice()).toString(), hre.config.defaults.mintPrice);
+      assert.equal((await Ethernauts.mintPrice()).toString(), hre.config.defaults.initialMintPrice);
     });
 
     it('shows that the expected interfaces are supported', async () => {

--- a/packages/hardhat/test/Mint.test.js
+++ b/packages/hardhat/test/Mint.test.js
@@ -26,9 +26,9 @@ describe('Mint', () => {
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
-    const params = Object.assign({}, hre.config.defaults);
-    params.maxTokens = 100;
-    params.maxGiftable = 10;
+    const params = { ...hre.config.defaults };
+    params.definitiveMaxGiftable = 10;
+    params.definitiveMaxTokens = 100;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -53,10 +53,10 @@ describe('Random', () => {
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
-    const params = Object.assign({}, hre.config.defaults);
-    params.maxTokens = maxTokens;
-    params.batchSize = batchSize;
-    params.maxGiftable = 0;
+    const params = { ...hre.config.defaults };
+    params.definitiveMaxGiftable = 0;
+    params.definitiveMaxTokens = maxTokens;
+    params.definitiveBatchSize = batchSize;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/hardhat/test/State.test.js
+++ b/packages/hardhat/test/State.test.js
@@ -16,9 +16,9 @@ describe('State Changes', () => {
   before('deploy contract', async () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
-    const params = Object.assign({}, hre.config.defaults);
-    params.maxTokens = 100;
-    params.maxGiftable = 10;
+    const params = { ...hre.config.defaults };
+    params.definitiveMaxGiftable = 10;
+    params.definitiveMaxTokens = 100;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });


### PR DESCRIPTION
Closes #179 
Closes #176 

This PR implements the following changes:
- Adds the `urlChanger` param to the constructor (so we don't have to make another tx after deploy)
- Compiles the contract before deployment (to be sure that we don't deploy an old one)
- On deployment script, it validates that all the constructor params are configured and in proper order
- Adds flags and params to the deploy script to make it more easy to understand and use
- Now the deploy script prompts for confirmation before doing the deployment (so we can check all the constructor params values)
- Some JS aesthetic updates throughout the code