### PR TITLE
Addresses all of maraoz "low" and "info" level suggestions

### DIFF
--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -13,6 +13,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     using Strings for uint256;
 
     error MaxGiftableTokensTooLarge();
+    error MaxTokensTooLarge();
     error CannotCallOnCurrentState();
     error NotEnoughETH();
     error NoTokensAvailable();
@@ -34,10 +35,8 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     event PermanentURISet(bool value);
     event UrlChangerChanged(address urlChanger);
 
-    // Hardcoded
-    uint256 public constant maxTokens = 10000;
-
     // Can be set only once on deploy
+    uint256 public immutable maxTokens;
     uint256 public immutable maxGiftableTokens;
     uint256 public immutable batchSize;
     bytes32 public immutable provenanceHash;
@@ -65,6 +64,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     SaleState public currentSaleState;
 
     constructor(
+        uint256 definitiveMaxTokens,
         uint256 definitiveMaxGiftableTokens,
         uint256 definitiveBatchSize,
         bytes32 definitiveProvenanceHash,
@@ -73,10 +73,15 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         address initialCouponSigner,
         address initialUrlChanger
     ) ERC721("Ethernauts", "NAUTS") {
+        if (definitiveMaxTokens > 10000) {
+            revert MaxTokensTooLarge();
+        }
+
         if (definitiveMaxGiftableTokens > 100) {
             revert MaxGiftableTokensTooLarge();
         }
 
+        maxTokens = definitiveMaxTokens;
         maxGiftableTokens = definitiveMaxGiftableTokens;
         batchSize = definitiveBatchSize;
         provenanceHash = definitiveProvenanceHash;

--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -409,12 +409,12 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     }
 
     function _generateRandomNumberIfNeeded(uint256 lastTokenId) private {
-        uint256 currentBatchId = getBatchForToken(lastTokenId);
-        if (_randomNumbers.length > currentBatchId) {
+        uint256 currentBatchNumber = getBatchForToken(lastTokenId);
+        if (_randomNumbers.length > currentBatchNumber) {
             return;
         }
 
-        uint256 maxTokenIdInBatch = getMaxTokenIdInBatch(currentBatchId);
+        uint256 maxTokenIdInBatch = getMaxTokenIdInBatch(currentBatchNumber);
         if (maxTokenIdInBatch > lastTokenId) {
             return;
         }

--- a/packages/hardhat/contracts/Ethernauts.sol
+++ b/packages/hardhat/contracts/Ethernauts.sol
@@ -18,7 +18,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
     error NotEnoughETH();
     error NoTokensAvailable();
     error CouponAlreadyRedeemed();
-    error CouponSignedForAnotherUser();
+    error InvalidCoupon();
     error NoGiftTokensAvailable();
     error BaseUriIsFrozen();
     error DoesNotChangeSaleState();
@@ -139,7 +139,7 @@ contract Ethernauts is ERC721Enumerable, Ownable {
         }
 
         if (!isCouponSignedForUser(msg.sender, signedCoupon)) {
-            revert CouponSignedForAnotherUser();
+            revert InvalidCoupon();
         }
 
         _redeemedCoupons[msg.sender] = true;

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -48,6 +48,7 @@ module.exports = {
     apiKey: `${process.env.ETHERSCAN_API}`,
   },
   defaults: {
+    definitiveMaxTokens: 10000,
     definitiveMaxGiftableTokens: 100,
     definitiveBatchSize: 50,
     definitiveProvenanceHash: '0xabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca',

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -48,8 +48,7 @@ module.exports = {
     apiKey: `${process.env.ETHERSCAN_API}`,
   },
   defaults: {
-    definitiveMaxGiftable: 100,
-    definitiveMaxTokens: 10000,
+    definitiveMaxGiftableTokens: 100,
     definitiveBatchSize: 50,
     definitiveProvenanceHash: '0xabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca',
 
@@ -65,4 +64,7 @@ module.exports = {
     gasPrice: ethers.utils.parseUnits('100', 'gwei'),
     gasLimit: 8000000,
   },
+  mocha: {
+    timeout: 120000,
+  }
 };

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -64,7 +64,4 @@ module.exports = {
     gasPrice: ethers.utils.parseUnits('100', 'gwei'),
     gasLimit: 8000000,
   },
-  mocha: {
-    timeout: 120000,
-  }
 };

--- a/packages/hardhat/test/Early.test.js
+++ b/packages/hardhat/test/Early.test.js
@@ -78,7 +78,7 @@ describe('Early mint', () => {
           Ethernauts.connect(user).mintEarly(coupon, {
             value: hre.config.defaults.initialEarlyMintPrice,
           }),
-          'CouponSignedForAnotherUser'
+          'InvalidCoupon'
         );
       });
     });
@@ -225,7 +225,7 @@ describe('Early mint', () => {
                 value: hre.config.defaults.initialEarlyMintPrice,
               }
             ),
-            'CouponSignedForAnotherUser'
+            'InvalidCoupon'
           );
         });
       });

--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -21,8 +21,7 @@ describe('Test events emitted', () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
     const params = { ...hre.config.defaults };
-    params.definitiveMaxGiftable = 10;
-    params.definitiveMaxTokens = 100;
+    params.definitiveMaxGiftableTokens = 10;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/hardhat/test/Events.test.js
+++ b/packages/hardhat/test/Events.test.js
@@ -83,17 +83,17 @@ describe('Test events emitted', () => {
   });
 
   describe('When Withdraw is triggered', () => {
-    it('shows WithdrawTriggered event is emitted', async () => {
+    it('shows ETHWithdrawn event is emitted', async () => {
       receipt = await (await Ethernauts.connect(owner).withdraw(user.address)).wait();
-      const event = receipt.events.find((e) => e.event === 'WithdrawTriggered');
+      const event = receipt.events.find((e) => e.event === 'ETHWithdrawn');
       assert.equal(event.args.beneficiary, user.address);
     });
   });
 
   describe('When PermanentURL is locked', () => {
-    it('shows PermanentURITriggered event is emitted', async () => {
+    it('shows PermanentURISet event is emitted', async () => {
       receipt = await (await Ethernauts.connect(owner).setPermanentURI()).wait();
-      const event = receipt.events.find((e) => e.event === 'PermanentURITriggered');
+      const event = receipt.events.find((e) => e.event === 'PermanentURISet');
       assert.equal(event.args.value, true);
     });
     context('and owner attempts to set baseURI', () => {

--- a/packages/hardhat/test/General.test.js
+++ b/packages/hardhat/test/General.test.js
@@ -19,18 +19,9 @@ describe('General', () => {
     describe('when deploying with too many giftable tokens', () => {
       it('reverts', async () => {
         const params = { ...hre.config.defaults };
-        params.definitiveMaxGiftable = 200;
+        params.definitiveMaxGiftableTokens = 200;
 
         await assertRevert(factory.deploy(...Object.values(params)), 'MaxGiftableTokensTooLarge');
-      });
-    });
-
-    describe('when deploying with too many tokens', () => {
-      it('reverts', async () => {
-        const params = { ...hre.config.defaults };
-        params.definitiveMaxTokens = 12000;
-
-        await assertRevert(factory.deploy(...Object.values(params)), 'MaxTokensTooLarge');
       });
     });
   });
@@ -59,12 +50,12 @@ describe('General', () => {
 
     it('shows the correct max supplies', async () => {
       assert.equal(
-        (await Ethernauts.maxGiftable()).toNumber(),
-        hre.config.defaults.definitiveMaxGiftable
+        (await Ethernauts.maxGiftableTokens()).toNumber(),
+        hre.config.defaults.definitiveMaxGiftableTokens
       );
       assert.equal(
         (await Ethernauts.maxTokens()).toNumber(),
-        hre.config.defaults.definitiveMaxTokens
+        10000
       );
     });
 

--- a/packages/hardhat/test/General.test.js
+++ b/packages/hardhat/test/General.test.js
@@ -24,6 +24,15 @@ describe('General', () => {
         await assertRevert(factory.deploy(...Object.values(params)), 'MaxGiftableTokensTooLarge');
       });
     });
+
+    describe('when deploying with too many tokens', () => {
+      it('reverts', async () => {
+        const params = { ...hre.config.defaults };
+        params.definitiveMaxTokens = 12000;
+
+        await assertRevert(factory.deploy(...Object.values(params)), 'MaxTokensTooLarge');
+      });
+    });
   });
 
   describe('when deploying the contract with valid paratemeters', () => {

--- a/packages/hardhat/test/General.test.js
+++ b/packages/hardhat/test/General.test.js
@@ -55,7 +55,7 @@ describe('General', () => {
       );
       assert.equal(
         (await Ethernauts.maxTokens()).toNumber(),
-        10000
+        hre.config.defaults.definitiveMaxTokens
       );
     });
 

--- a/packages/hardhat/test/Gift.test.js
+++ b/packages/hardhat/test/Gift.test.js
@@ -89,7 +89,8 @@ describe('Gift', () => {
   describe('when trying to gift more than the maximum amount of giftable tokens', () => {
     before('mint max -1', async () => {
       const num =
-        (await Ethernauts.maxGiftable()).toNumber() - (await Ethernauts.tokensGifted()).toNumber();
+        (await Ethernauts.maxGiftableTokens()).toNumber() -
+        (await Ethernauts.tokensGifted()).toNumber();
 
       let promises = [];
       for (let i = 0; i < num; i++) {

--- a/packages/hardhat/test/Mint.test.js
+++ b/packages/hardhat/test/Mint.test.js
@@ -26,8 +26,7 @@ describe('Mint', () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
     const params = { ...hre.config.defaults };
-    params.definitiveMaxGiftable = 10;
-    params.definitiveMaxTokens = 100;
+    params.definitiveMaxGiftableTokens = 10;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });
@@ -193,7 +192,7 @@ describe('Mint', () => {
       before('mint all', async () => {
         const num =
           (await Ethernauts.maxTokens()).toNumber() -
-          (await Ethernauts.maxGiftable()).toNumber() -
+          (await Ethernauts.maxGiftableTokens()).toNumber() -
           (await Ethernauts.totalSupply()).toNumber();
 
         let promises = [];
@@ -212,6 +211,10 @@ describe('Mint', () => {
 
       it('shows that no more tokens are available to mint', async function () {
         assert.equal(await Ethernauts.availableToMint(), 0);
+      });
+
+      it('shows that the totaly supply is 10000', async function () {
+        assert.equal(await Ethernauts.totalSupply(), 10000);
       });
 
       describe('when trying to mint more than the maximum amount of Ethernauts', () => {

--- a/packages/hardhat/test/Mint.test.js
+++ b/packages/hardhat/test/Mint.test.js
@@ -26,6 +26,7 @@ describe('Mint', () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
     const params = { ...hre.config.defaults };
+    params.definitiveMaxTokens = 100;
     params.definitiveMaxGiftableTokens = 10;
 
     Ethernauts = await factory.deploy(...Object.values(params));

--- a/packages/hardhat/test/Mint.test.js
+++ b/packages/hardhat/test/Mint.test.js
@@ -213,10 +213,6 @@ describe('Mint', () => {
         assert.equal(await Ethernauts.availableToMint(), 0);
       });
 
-      it('shows that the totaly supply is 10000', async function () {
-        assert.equal(await Ethernauts.totalSupply(), 10000);
-      });
-
       describe('when trying to mint more than the maximum amount of Ethernauts', () => {
         it('reverts', async () => {
           await assertRevert(

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -21,9 +21,9 @@ describe('Random', () => {
   }
 
   function calculateAssetId(tokenId, randomNumber) {
-    const batchId = Math.floor(tokenId / batchSize);
+    const batchNumber = Math.floor(tokenId / batchSize);
     const offset = randomNumber.mod(ethers.BigNumber.from(batchSize)).toNumber();
-    const maxTokenIdInBatch = batchSize * (batchId + 1) - 1;
+    const maxTokenIdInBatch = batchSize * (batchNumber + 1) - 1;
 
     let assetId = tokenId + offset;
     if (assetId > maxTokenIdInBatch) {

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -34,13 +34,19 @@ describe('Random', () => {
   }
 
   async function validateTokenUri(tokenId, randomNumber) {
-    const fromContract = await Ethernauts.tokenURI(tokenId);
-    const expected = `${baseURI}${calculateAssetId(tokenId, randomNumber)}`;
+    const { assetId } = await Ethernauts.getAssetIdForTokenId(tokenId);
+    const calculatedAssetId = calculateAssetId(tokenId, randomNumber);
+    assert.equal(assetId, calculatedAssetId);
 
+    const fromContract = await Ethernauts.tokenURI(tokenId);
+    const expected = `${baseURI}${calculatedAssetId}`;
     assert.equal(fromContract, expected);
   }
 
   async function validateTempTokenUri(tokenId) {
+    const { assetAvailable } = await Ethernauts.getAssetIdForTokenId(tokenId);
+    assert.equal(assetAvailable, false);
+
     const fromContract = await Ethernauts.tokenURI(tokenId);
     const expected = `${baseURI}travelling_to_destination`;
 
@@ -55,8 +61,7 @@ describe('Random', () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
     const params = { ...hre.config.defaults };
-    params.definitiveMaxGiftable = 0;
-    params.definitiveMaxTokens = maxTokens;
+    params.definitiveMaxGiftableTokens = 0;
     params.definitiveBatchSize = batchSize;
 
     Ethernauts = await factory.deploy(...Object.values(params));
@@ -76,6 +81,22 @@ describe('Random', () => {
         Ethernauts.connect(user).generateRandomNumber(),
         'caller is not the owner'
       );
+    });
+  });
+
+  describe('when querying batch numbers', function () {
+    it('responds with the expected values', async function () {
+      assert.equal((await Ethernauts.getBatchForToken(0)).toNumber(), 0);
+      assert.equal((await Ethernauts.getBatchForToken(2 * batchSize)).toNumber(), 2);
+      assert.equal((await Ethernauts.getBatchForToken(42 * batchSize)).toNumber(), 42);
+    });
+  });
+
+  describe('when querying max token ids in batches', function () {
+    it('responds with the expected values', async function () {
+      assert.equal((await Ethernauts.getMaxTokenIdInBatch(0)).toNumber(), batchSize - 1);
+      assert.equal((await Ethernauts.getMaxTokenIdInBatch(1)).toNumber(), 2 * batchSize - 1);
+      assert.equal((await Ethernauts.getMaxTokenIdInBatch(42)).toNumber(), 43 * batchSize - 1);
     });
   });
 

--- a/packages/hardhat/test/Random.test.js
+++ b/packages/hardhat/test/Random.test.js
@@ -62,6 +62,7 @@ describe('Random', () => {
 
     const params = { ...hre.config.defaults };
     params.definitiveMaxGiftableTokens = 0;
+    params.definitiveMaxTokens = maxTokens;
     params.definitiveBatchSize = batchSize;
 
     Ethernauts = await factory.deploy(...Object.values(params));

--- a/packages/hardhat/test/Recovery.test.js
+++ b/packages/hardhat/test/Recovery.test.js
@@ -60,7 +60,7 @@ describe('Recovery', () => {
     it('reverts', async () => {
       await assertRevert(
         Ethernauts.connect(owner).recoverTokens(Token.address, owner.address, totalSupply),
-        'InsufficientTokenBalance'
+        'InsufficientERC20TokenBalance'
       );
     });
   });

--- a/packages/hardhat/test/State.test.js
+++ b/packages/hardhat/test/State.test.js
@@ -42,7 +42,7 @@ describe('State Changes', () => {
   });
 
   it('state cannot be overriden with the same value', async () => {
-    await assertRevert(Ethernauts.connect(owner).setSaleState(0), 'NoChange');
+    await assertRevert(Ethernauts.connect(owner).setSaleState(0), 'DoesNotChangeSaleState');
     assert.equal(await Ethernauts.currentSaleState(), 0);
   });
 });

--- a/packages/hardhat/test/State.test.js
+++ b/packages/hardhat/test/State.test.js
@@ -18,6 +18,7 @@ describe('State Changes', () => {
 
     const params = { ...hre.config.defaults };
     params.definitiveMaxGiftableTokens = 10;
+    params.definitiveMaxTokens = 100;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/hardhat/test/State.test.js
+++ b/packages/hardhat/test/State.test.js
@@ -17,8 +17,7 @@ describe('State Changes', () => {
     const factory = await ethers.getContractFactory('Ethernauts');
 
     const params = { ...hre.config.defaults };
-    params.definitiveMaxGiftable = 10;
-    params.definitiveMaxTokens = 100;
+    params.definitiveMaxGiftableTokens = 10;
 
     Ethernauts = await factory.deploy(...Object.values(params));
   });

--- a/packages/keeper/contracts/Ethernauts.sol
+++ b/packages/keeper/contracts/Ethernauts.sol
@@ -5,7 +5,7 @@ import {Ethernauts as EthernautsBase} from "@ethernauts/hardhat/contracts/Ethern
 
 contract Ethernauts is EthernautsBase {
     constructor(
-        uint256 definitiveMaxGiftable,
+        uint256 definitiveMaxGiftableTokens,
         uint256 definitiveMaxTokens,
         uint256 definitiveBatchSize,
         bytes32 definitiveProvenanceHash,
@@ -15,7 +15,7 @@ contract Ethernauts is EthernautsBase {
         address initialUrlChanger
     )
         EthernautsBase(
-            definitiveMaxGiftable,
+            definitiveMaxGiftableTokens,
             definitiveMaxTokens,
             definitiveBatchSize,
             definitiveProvenanceHash,

--- a/packages/keeper/scripts/queue.js
+++ b/packages/keeper/scripts/queue.js
@@ -26,19 +26,19 @@ async function main() {
     if (from !== '0x0000000000000000000000000000000000000000') return;
 
     tokenId = Number(tokenId);
-    const batchId = Math.floor(tokenId / batchSize);
-    const maxTokenIdInBatch = batchSize * (batchId + 1) - 1;
+    const batchNumber = Math.floor(tokenId / batchSize);
+    const maxTokenIdInBatch = batchSize * (batchNumber + 1) - 1;
 
     console.log('Transfer:', JSON.stringify({ to, tokenId }));
 
     if (tokenId == maxTokenIdInBatch) {
-      console.log('BatchEnd:', JSON.stringify({ batchId, maxTokenIdInBatch }));
+      console.log('BatchEnd:', JSON.stringify({ batchNumber, maxTokenIdInBatch }));
 
       await queue.add({
         name: JOB_PROCESS_BATCH,
         queueName: config.MINTS_QUEUE_NAME,
         data: {
-          batchId,
+          batchNumber,
           batchSize,
         },
       });

--- a/packages/keeper/src/process-jobs.js
+++ b/packages/keeper/src/process-jobs.js
@@ -8,12 +8,12 @@ const jobs = {
   /**
    * Generate all the necessary jobs for uploading the assets
    */
-  [JOB_PROCESS_BATCH]: async function ({ batchId, batchSize }, { Ethernauts, queue }) {
-    const randomNumber = await Ethernauts.getRandomNumberForBatch(batchId);
+  [JOB_PROCESS_BATCH]: async function ({ batchNumber, batchSize }, { Ethernauts, queue }) {
+    const randomNumber = await Ethernauts.getRandomNumberForBatch(batchNumber);
     const offset = Number(randomNumber.mod(batchSize));
 
-    const minTokenIdInBatch = batchSize * batchId;
-    const maxTokenIdInBatch = batchSize * (batchId + 1) - 1;
+    const minTokenIdInBatch = batchSize * batchNumber;
+    const maxTokenIdInBatch = batchSize * (batchNumber + 1) - 1;
 
     const children = [];
     for (let tokenId = minTokenIdInBatch; tokenId <= maxTokenIdInBatch; tokenId++) {
@@ -33,7 +33,7 @@ const jobs = {
       children,
     });
 
-    return { batchId, minTokenIdInBatch, maxTokenIdInBatch };
+    return { batchNumber, minTokenIdInBatch, maxTokenIdInBatch };
   },
 
   /**


### PR DESCRIPTION
Fix #205, #202

### low
- [X] comment on line 285 reads "Can only be called if NFTs arent done minting.", which doesn't seem to be correct (permanentUrl can be set by the owner at any time). fix the code or the comment.
* Corrected, and renamed permanentUrl to permanentURI

- [X] any coupons signed by couponSigner will be invalid after calling setCouponSigner because of the check in line 191
* Given that we store users that redeemed coupons, and that we intend to have one coupon per user, we should be able to recover from a change in couponSigner.

- [X] I think CouponSignedForAnotherUser name is misleading. Won't that revert occur when the signature is from an old coupon signer, instead of "for another user", as the name implies? Seems to me like that if the coupon is for another user, the signature check will fail before that revert (sorry to report this as a question, but you guys can check it easily)
* Yes! Renamed to InvalidCoupon. Tests checked and both cases are covered, bad signer and users trying to present other user's coupons.

### info / suggestions
- [X] contract allows state to go back to 'Early' from 'Open'.
* Agreed. We want to leave the possibility open in case we have problems.

- [X] rename maxGiftable to maxGiftableTokens for clarity.
* Renamed.

- [X] create and test (edge cases) a view function getCurrentBatch that returns tokenId / batchSize to reduce code repetition.
* Done.

- [X] create and test (edge cases) a view function getMaxTokenIdInBatch(batch) that returns batchSize * (batchId + 1) - 1 to reduce code repetition.
* Done.

- [X] create and test (edge cases) a view function getAssetIDForTokenID() that returns the assetId for each tokenId. Use that in tokenURI().
* Done.

- [X] change definitiveMaxTokens from constructor argument to a constant equal to 10000 and remove MaxTokensTooLarge.
* We'd like to keep it because it makes tests so much easier. The use of `immutable` should provide the same, only if slightly less readable, guarantees.

- [X] Consider renaming NoChange to NoSaleStateChange
* Done.

- [X] Consider renaming InsufficientTokenBalance to InsufficientERC20Balance to avoid confusion with the Ethernaut token.
* Done.

- [X] Consider using !isTokenRevealed() in line 208 for more clarity (line 207 can be moved below that check)
* Done.

- [X] Consider renaming batchId everywhere to batch. (same with currentBatchId to currentBatch)
* Done.

- [X] when deploying, remember mintPrice and earlyMintPrice units are in wei! careful with deployment scripts using JavaScript numbers which can have weird behavior with big numbers (unless you're using BigNumber / BN). Same with the setter function. double check any scripts calling those (or consider removing the setters unless absolutely needed).
* Checked! All good.

- [X] Consider making urlChanger immutable and removing the setter. Given that the owner can also change the URL this state change seems unnecessary to me. If so, remove UrlChangerChanged too.
* Agreed, but we prefer to keep it. Even if the owner can change it, it would be cumbersome considering its a 4/8 multisig.
