### PR TITLE
Add provenance hash generator script

### DIFF
--- a/packages/hardhat/scripts/create-dummy-assets.js
+++ b/packages/hardhat/scripts/create-dummy-assets.js
@@ -12,14 +12,17 @@ const constants = require('../src/constants');
 const fileExists = require('../src/utils/file-exists');
 
 async function main() {
-  if (await fileExists(path.join(constants.ASSETS_FOLDER, '0.png'))) {
+  if (await fileExists(path.join(constants.RESOURCES_ASSETS_FOLDER, '0.png'))) {
     const confirm = new Confirm('Do you want to recreate the assets and metadata?');
     const yes = await confirm.run();
     if (!yes) return;
-    await del([constants.ASSETS_FOLDER, constants.METADATA_FOLDER]);
+    await del([constants.RESOURCES_ASSETS_FOLDER, constants.RESOURCES_METADATA_FOLDER]);
   }
 
-  await Promise.all([makeDir(constants.ASSETS_FOLDER), makeDir(constants.METADATA_FOLDER)]);
+  await Promise.all([
+    makeDir(constants.RESOURCES_ASSETS_FOLDER),
+    makeDir(constants.RESOURCES_METADATA_FOLDER),
+  ]);
 
   const _r = random.exponential(10.1);
   const getRarity = () => {
@@ -50,8 +53,8 @@ async function main() {
 
     rarities.push(metadata.rarity);
 
-    const assetPath = path.join(constants.ASSETS_FOLDER, `${x}.png`);
-    const metadataPath = path.join(constants.METADATA_FOLDER, `${x}.json`);
+    const assetPath = path.join(constants.RESOURCES_ASSETS_FOLDER, `${x}.png`);
+    const metadataPath = path.join(constants.RESOURCES_METADATA_FOLDER, `${x}.json`);
 
     promises.push(
       fs.promises.writeFile(assetPath, png.getBuffer()),

--- a/packages/hardhat/scripts/create-ipfs-metadata.js
+++ b/packages/hardhat/scripts/create-ipfs-metadata.js
@@ -1,27 +1,30 @@
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs/promises');
 
 const constants = require('../src/constants');
 const fileExists = require('../src/utils/file-exists');
 const { getIPFSHash } = require('../src/utils/ipfs-uri');
 
 async function main() {
-  if (!(await fileExists(path.join(constants.METADATA_FOLDER, '0.json')))) {
+  if (!(await fileExists(path.join(constants.RESOURCES_METADATA_FOLDER, '0.json')))) {
     throw new Error('Metadata are needed');
   }
-  const assets = await fs.promises.readdir(constants.ASSETS_FOLDER);
+  const assets = await fs.readdir(constants.RESOURCES_ASSETS_FOLDER);
 
   if (!assets.length) throw new Error('Assets are needed');
 
   return Promise.all(
     assets.map(async (asset) => {
-      const filepath = path.join(constants.ASSETS_FOLDER, asset);
+      const filepath = path.join(constants.RESOURCES_ASSETS_FOLDER, asset);
 
-      const metadataPath = path.join(constants.METADATA_FOLDER, `${path.parse(asset).name}.json`);
+      const metadataPath = path.join(
+        constants.RESOURCES_METADATA_FOLDER,
+        `${path.parse(asset).name}.json`
+      );
 
       const [file, metadata] = await Promise.all([
-        fs.promises.readFile(filepath),
-        fs.promises.readFile(metadataPath),
+        fs.readFile(filepath),
+        fs.readFile(metadataPath),
       ]);
 
       const ipfsHash = await getIPFSHash(file);
@@ -31,7 +34,7 @@ async function main() {
         image: constants.IPFS_PREFIX + ipfsHash,
       };
 
-      return fs.promises.writeFile(metadataPath, JSON.stringify(metadataWithIpfs, null, 2));
+      return fs.writeFile(metadataPath, JSON.stringify(metadataWithIpfs, null, 2));
     })
   );
 }

--- a/packages/hardhat/scripts/create-provenance-hash.js
+++ b/packages/hardhat/scripts/create-provenance-hash.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const fs = require('fs/promises');
+const crypto = require('crypto');
+
+const constants = require('../src/constants');
+const fileExists = require('../src/utils/file-exists');
+
+async function main() {
+  if (!(await fileExists(path.join(constants.RESOURCES_METADATA_FOLDER, '0.json')))) {
+    throw new Error('Metadata files are needed');
+  }
+
+  const metadataFiles = (await fs.readdir(constants.RESOURCES_METADATA_FOLDER)).filter(
+    (name) => path.extname(name) === '.json'
+  );
+
+  const ipfsHashes = await Promise.all(
+    metadataFiles.map(async (filename) => {
+      const filepath = path.join(constants.RESOURCES_METADATA_FOLDER, filename);
+      const metadata = JSON.parse(await fs.readFile(filepath)).image;
+      return metadata.slice(constants.IPFS_PREFIX.length);
+    })
+  );
+
+  const concatenated = ipfsHashes.join('');
+  const provenanceHash = crypto.createHash('md5').update(concatenated).digest('hex');
+
+  console.log('=== Concatenated Hashes ===');
+  console.log(concatenated);
+  console.log('---------------------------');
+  console.log('=== Provenance MD5 Hash ===');
+  console.log(provenanceHash);
+  console.log('---------------------------');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/hardhat/src/constants.js
+++ b/packages/hardhat/src/constants.js
@@ -6,16 +6,16 @@ const IPFS_PREFIX = 'ipfs://';
 const DAPP_FOLDER = path.resolve(__dirname, '..', '..', 'dapp');
 const DATA_DAPP_FOLDER = path.join(DAPP_FOLDER, 'data');
 
-const RESOURCES_FOLDER = path.resolve(__dirname, '..', 'resources');
-const ASSETS_FOLDER = path.join(RESOURCES_FOLDER, 'assets');
-const METADATA_FOLDER = path.join(RESOURCES_FOLDER, 'metadata');
+const RESOURCES_METADATA_FOLDER =
+  process.env.RESOURCES_METADATA_FOLDER || path.join(__dirname, '..', 'resources', 'metadata');
+const RESOURCES_ASSETS_FOLDER =
+  process.env.RESOURCES_ASSETS_FOLDER || path.join(__dirname, '..', 'resources', 'assets');
 
 module.exports = {
   TOTAL_ASSETS,
   IPFS_PREFIX,
   DAPP_FOLDER,
   DATA_DAPP_FOLDER,
-  RESOURCES_FOLDER,
-  ASSETS_FOLDER,
-  METADATA_FOLDER,
+  RESOURCES_METADATA_FOLDER,
+  RESOURCES_ASSETS_FOLDER,
 };


### PR DESCRIPTION
This scripts grabs all the metadata files, and from the IPFS hashes of each asset generates in correct order a provenanceHash, which is the value that has to be added on the Ethernauts contract deployment, and then can be used to validated the assets order before any mints happened.